### PR TITLE
Refactor methods and make them more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import 'package:number_translator/number_translator.dart';
 From English:
 
 ```
-String translatedNumber = NumberTranslator().fromEn('123', toLanguage: 'bn');
+String translatedNumber = NumberTranslator.translate('123', toLanguage: Language.bangla);
 print(translatedNumber); // Output: '১২৩'
 
 ```
@@ -38,7 +38,7 @@ print(translatedNumber); // Output: '১২৩'
 To English:
 
 ```
-String translatedNumber = NumberTranslator().toEn('১২৩');
+String translatedNumber = NumberTranslator.translateToEnglish('১২৩');
 print(translatedNumber); // Output: '123'
 ```
 

--- a/lib/number_translator.dart
+++ b/lib/number_translator.dart
@@ -1,3 +1,4 @@
 library number_translator;
 
 export 'src/number_translator.dart';
+export 'src/languages.dart';

--- a/lib/src/languages.dart
+++ b/lib/src/languages.dart
@@ -1,0 +1,17 @@
+class Language {
+  String _code = "en";
+
+  String get code => _code;
+
+  static Language english = Language._(code: 'en');
+  static Language arabic = Language._(code: 'ar');
+  static Language bangla = Language._(code: 'bn');
+  static Language hindi = Language._(code: 'hi');
+  static Language chinese = Language._(code: 'zh');
+
+  Language._({required String code}) {
+    this._code = code;
+  }
+}
+
+

--- a/lib/src/number_translator.dart
+++ b/lib/src/number_translator.dart
@@ -1,87 +1,18 @@
-import 'constents.dart';
+import 'languages.dart';
+import 'utils.dart' as utils;
 
 class NumberTranslator {
-  String fromEn(String inputs, {String toLanguage = 'en'}) {
-    if (!toEnglishNumbersMapping.containsKey(toLanguage)) {
-      return 'Language code not found!';
-    }
-    List<String> mapping = fromEnglishNumbersMapping[toLanguage]!;
-    List<String> digits = inputs.split('');
+  NumberTranslator._();
 
-    String result = '';
-
-    for (String digit in digits) {
-      int index = int.tryParse(digit) ?? -1;
-
-      if (index >= 0 && index < mapping.length) {
-        result += mapping[index];
-      } else {
-        result += digit;
-      }
-    }
-    return result;
+  static String translate(String input, {Language? toLanguage}) {
+    return utils.fromEn(input, toLanguage: toLanguage?.code ?? Language.english.code);
   }
 
-  String toEn(String inputs) {
-    String result = '';
-    String fromLanguage = detectLanguage(inputs);
-
-    Map<String, String> mapping = toEnglishNumbersMapping[fromLanguage]!;
-    List<String> digits = inputs.split('');
-
-    for (int i = 0; i < digits.length; i++) {
-      result += mapping[digits[i]] ?? digits[i];
-    }
-
-    if (fromLanguage == 'zh') {
-      switch (result) {
-        case '一〇':
-          return '十';
-        case '一〇〇':
-          return '一百';
-        case '一〇〇〇':
-          return '一千';
-        case '一〇〇〇〇':
-          return '一万';
-        case '一〇〇〇〇〇':
-          return '十万';
-        case '一〇〇〇〇〇〇':
-          return '一百万';
-        default:
-          break;
-      }
-    }
-
-    return result;
+  static String translateToEnglish(String input) {
+    return utils.toEn(input);
   }
 
-  String detectLanguage(String input) {
-    // Assuming input is a single character (number)
-    String firstChar = input.substring(0, 1);
-
-    // Check if the character belongs to the English number range
-    if (firstChar.codeUnitAt(0) >= 48 && firstChar.codeUnitAt(0) <= 57) {
-      return 'en';
-    }
-    // Check if the character belongs to the Arabic number range
-    else if (firstChar.codeUnitAt(0) >= 0x0660 &&
-        firstChar.codeUnitAt(0) <= 0x0669) {
-      return 'ar';
-    }
-    // Check if the character belongs to the Bangla number range
-    else if (firstChar.codeUnitAt(0) >= 0x09E6 &&
-        firstChar.codeUnitAt(0) <= 0x09EF) {
-      return 'bn';
-    }
-    // Check if the character belongs to the Devanagari number range (Hindi)
-    else if (firstChar.codeUnitAt(0) >= 0x0966 &&
-        firstChar.codeUnitAt(0) <= 0x096F) {
-      return 'hi';
-    } else if (firstChar.codeUnitAt(0) >= 0x4E00 &&
-        firstChar.codeUnitAt(0) <= 0x9FFF) {
-      return 'zh';
-    } else {
-      return 'en';
-    }
+  static String detectLanguage({required String input}) {
+    return utils.detectLanguage(input);
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,0 +1,85 @@
+import 'constents.dart';
+
+String fromEn(String inputs, {String toLanguage = 'en'}) {
+  if (!toEnglishNumbersMapping.containsKey(toLanguage)) {
+    return 'Language code not found!';
+  }
+  List<String> mapping = fromEnglishNumbersMapping[toLanguage]!;
+  List<String> digits = inputs.split('');
+
+  String result = '';
+
+  for (String digit in digits) {
+    int index = int.tryParse(digit) ?? -1;
+
+    if (index >= 0 && index < mapping.length) {
+      result += mapping[index];
+    } else {
+      result += digit;
+    }
+  }
+  return result;
+}
+
+String toEn(String inputs) {
+  String result = '';
+  String fromLanguage = detectLanguage(inputs);
+
+  Map<String, String> mapping = toEnglishNumbersMapping[fromLanguage]!;
+  List<String> digits = inputs.split('');
+
+  for (int i = 0; i < digits.length; i++) {
+    result += mapping[digits[i]] ?? digits[i];
+  }
+
+  if (fromLanguage == 'zh') {
+    switch (result) {
+      case '一〇':
+        return '十';
+      case '一〇〇':
+        return '一百';
+      case '一〇〇〇':
+        return '一千';
+      case '一〇〇〇〇':
+        return '一万';
+      case '一〇〇〇〇〇':
+        return '十万';
+      case '一〇〇〇〇〇〇':
+        return '一百万';
+      default:
+        break;
+    }
+  }
+
+  return result;
+}
+
+String detectLanguage(String input) {
+// Assuming input is a single character (number)
+  String firstChar = input.substring(0, 1);
+
+// Check if the character belongs to the English number range
+  if (firstChar.codeUnitAt(0) >= 48 && firstChar.codeUnitAt(0) <= 57) {
+    return 'en';
+  }
+// Check if the character belongs to the Arabic number range
+  else if (firstChar.codeUnitAt(0) >= 0x0660 &&
+      firstChar.codeUnitAt(0) <= 0x0669) {
+    return 'ar';
+  }
+// Check if the character belongs to the Bangla number range
+  else if (firstChar.codeUnitAt(0) >= 0x09E6 &&
+      firstChar.codeUnitAt(0) <= 0x09EF) {
+    return 'bn';
+  }
+// Check if the character belongs to the Devanagari number range (Hindi)
+  else if (firstChar.codeUnitAt(0) >= 0x0966 &&
+      firstChar.codeUnitAt(0) <= 0x096F) {
+    return 'hi';
+  } else if (firstChar.codeUnitAt(0) >= 0x4E00 &&
+      firstChar.codeUnitAt(0) <= 0x9FFF) {
+    return 'zh';
+  } else {
+    return 'en';
+  }
+}


### PR DESCRIPTION
- use `Language` class instead of hardcoded string for languages parameters
- prevent creating instance of NumberTranslator class (this is a utility class)
- use static method instead of instance methods
- make method names more readable